### PR TITLE
Document metadata for JSON mime-type

### DIFF
--- a/docs/messaging.rst
+++ b/docs/messaging.rst
@@ -998,6 +998,13 @@ of images::
       }
     }
 
+and expanded for JSON data::
+
+    metadata = {
+      'application/json' : {
+        'expanded': True
+      }
+    }
 
 .. versionchanged:: 5.0
 


### PR DESCRIPTION
Closes https://github.com/jupyter/jupyter_client/issues/214
